### PR TITLE
[android-security-13.0.0_r10] Fix vulnerability in CallRedirectionService.

### DIFF
--- a/src/com/android/server/telecom/callredirection/CallRedirectionProcessor.java
+++ b/src/com/android/server/telecom/callredirection/CallRedirectionProcessor.java
@@ -175,6 +175,20 @@ public class CallRedirectionProcessor implements CallRedirectionCallback {
                     Log.endSession();
                 }
             }
+
+            @Override
+            public void onBindingDied(ComponentName componentName) {
+                // Make sure we unbind the service if binding died to avoid background stating
+                // activity leaks
+                Log.startSession("CRSC.oBD");
+                try {
+                    synchronized (mTelecomLock) {
+                        finishCallRedirection();
+                    }
+                } finally {
+                    Log.endSession();
+                }
+            }
         }
 
         private class CallRedirectionAdapter extends ICallRedirectionAdapter.Stub {


### PR DESCRIPTION
Currently when the CallRedirectionService binding died, we didn't do anything, which cause malicious app start activities even not run in the background by implementing a CallRedirectionService and overriding the onPlaceCall method to schedule a activity start job in an independent process and then kill itself. In that way, the activity can still start after the CallRedirectionService died. Fix this by unbinding the service when the binding died.

Bug: b/289809991
Test: Using testapp provided in bug to make sure the test activity can't be started
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:29b52e3cd027da2d8644450a4dee3a7d95dc0043) Merged-In: I065d361b83700474a1efab2a75928427ee0a14ba Change-Id: I065d361b83700474a1efab2a75928427ee0a14ba