### PR TITLE
fix createLaunchEmergencyDialerIntent() crash in non-main users

### DIFF
--- a/src/com/android/server/telecom/TelecomServiceImpl.java
+++ b/src/com/android/server/telecom/TelecomServiceImpl.java
@@ -2050,7 +2050,9 @@ public class TelecomServiceImpl {
                     com.android.internal.R.string.config_emergency_dialer_package);
             Intent intent = new Intent(Intent.ACTION_DIAL_EMERGENCY)
                     .setPackage(packageName);
-            ResolveInfo resolveInfo = mPackageManager.resolveActivity(intent, 0 /* flags*/);
+            PackageManager pm = mContext.createContextAsUser(Binder.getCallingUserHandle(), 0)
+                    .getPackageManager();
+            ResolveInfo resolveInfo = pm.resolveActivity(intent, 0 /* flags*/);
             if (resolveInfo == null) {
                 // No matching activity from config, fallback to default platform implementation
                 intent.setPackage(null);


### PR DESCRIPTION
TelecomServiceImpl and PackageManagerService both run inside the system_server, which means that caller checks that are performed by mPackageManager.resolveActivity() are made against caller of createLaunchEmergencyDialerIntent() instead of against TelecomServiceImpl itself.

This leads to an implicit and unnecessary requirement for callers to hold the privileged INTERACT_ACROSS_USERS permission if they are running in a non-main user (mPackageManager is derived from the context of the main user).