### PR TITLE
fix InCallController.getInCallServiceComponents() in secondary users

### DIFF
--- a/src/com/android/server/telecom/InCallController.java
+++ b/src/com/android/server/telecom/InCallController.java
@@ -2373,10 +2373,10 @@ public class InCallController extends CallsManagerListenerBase implements
                                 TelecomManager.METADATA_INCLUDE_SELF_MANAGED_CALLS, false);
 
                 int currentType = getInCallServiceType(userHandle,
-                        entry.serviceInfo, packageManager, packageName);
+                        entry.serviceInfo, userPackageManager, packageName);
 
                 boolean hasInteractAcrossUserOrProfilePerm = canInteractAcrossUsersOrProfiles(
-                        entry.serviceInfo, packageManager);
+                        entry.serviceInfo, userPackageManager);
 
                 ComponentName foundComponentName =
                         new ComponentName(serviceInfo.packageName, serviceInfo.name);


### PR DESCRIPTION
Several permission checks in InCallController.getInCallServiceComponents() were ignoring the package's userId and instead always used the USER_SYSTEM (0) userId.

This broke support for secondary-user-only in-call service host packages, such as non-preinstalled Android Auto.