### PR TITLE
Telecom: allow Android Auto to resolve PhoneAccounts for SIM disambiguation

### DIFF
--- a/src/com/android/server/telecom/TelecomServiceImpl.java
+++ b/src/com/android/server/telecom/TelecomServiceImpl.java
@@ -3887,6 +3887,16 @@ public class TelecomServiceImpl {
             // ignore
         }
 
+        // Needed for calls with multi sim phones, since AA cannot hold
+        // READ_PRIVILEGED_PHONE_STATE as a sandboxed app, causing getPhoneAccount()
+        // to fail and SIM selection to never appear. Mirrors getUserSelectedOutgoingPhoneAccount.
+        try {
+            mContext.enforceCallingOrSelfPermission(android.Manifest.permission.READ_PRIVILEGED_PHONE_STATE_ANDROID_AUTO, null);
+            return true;
+        } catch (SecurityException e) {
+            // ignore
+        }
+
         try {
             mContext.enforceCallingOrSelfPermission(READ_PRIVILEGED_PHONE_STATE, null);
             return true;


### PR DESCRIPTION
related issue: GrapheneOS/os-issue-tracker#3166

I mirrored the permission used in `getUserSelectedOutgoingPhoneAccount`:
https://github.com/GrapheneOS/platform_packages_services_Telecomm/blob/c96509c769b56d490a09978191db08e11a08cb09/src/com/android/server/telecom/TelecomServiceImpl.java#L396
to add a similar case to `canGetPhoneAccount`, since Android Auto is running sandboxed and can therefore not match against any of the other required permissions. 

For the `try` / `catch` I used the same logic as in the clause above:
https://github.com/GrapheneOS/platform_packages_services_Telecomm/blob/c96509c769b56d490a09978191db08e11a08cb09/src/com/android/server/telecom/TelecomServiceImpl.java#L3881-L3888